### PR TITLE
Subtables are validated when validate is called

### DIFF
--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -242,10 +242,10 @@ class SubTableColumn(Column, Generic[T]):
         schema = self.schema.with_metadata(metadata)
 
         subtable = pa.Table.from_arrays(array.flatten(), schema=schema)
-        # We don't validate the subtable. If the parent table were validated,
+        # We don't validate the subtable. If the parent table was validated,
         # then the subtable would have been validated as part of that process.
         # If the parent table is intentionally not validated, then we don't
-        # want to validate the subtable either as it will throw an error
+        # want to validate the subtable at this time as it will throw an error
         # when accessing the subtable as a column (e.g. during concatenation).
         return self.table_type.from_pyarrow(subtable, permit_nulls=self.nullable, validate=False)
 

--- a/test/test_attributes.py
+++ b/test/test_attributes.py
@@ -166,8 +166,11 @@ class TestConstructors:
             name = qv.StringAttribute()
 
         df = pd.DataFrame({"inner.x": [1, 2, 3], "y": [4, 5, 6]})
+        # Set the dataframe attributes
+        df.attrs["inner"] = {"id": 10}
         table = Outer.from_flat_dataframe(df, name="foo")
         assert table.name == "foo"
+        assert table.inner.id == 10
 
     def test_from_kwargs(self):
         table = self.MyTable.from_kwargs(name="foo", vals=[1, 2, 3])

--- a/test/test_concat.py
+++ b/test/test_concat.py
@@ -87,12 +87,10 @@ def test_concatenate_no_validate():
     with pytest.raises(qv.ValidationError, match="Column x failed validation"):
         qv.concatenate([invalid_x, valid])
 
-    have = qv.concatenate([invalid_x, valid], validate=False)
-    assert len(have) == 2
+    with pytest.raises(qv.ValidationError, match="Column y failed validation"):
+        qv.concatenate([valid, invalid_subtable])
 
-    # Subtables are not validated during concatenation, as the main table
-    # was initialized with validate=False
-    have = qv.concatenate([valid, invalid_subtable])
+    have = qv.concatenate([invalid_x, valid], validate=False)
     assert len(have) == 2
 
 


### PR DESCRIPTION
I think this is finally correct.
Validate is called properly on subtables when `table.validate()` is called.
Concatenate will validation everything by default, but not validate anything when validate=False
Fixed a bug in loading from flat tables where required attributes could be missing.