### PR TITLE
Performance fixes for hot paths in quivr

### DIFF
--- a/quivr/columns.py
+++ b/quivr/columns.py
@@ -232,14 +232,33 @@ class SubTableColumn(Column, Generic[T]):
     def __get__(self, obj: Optional[tables.Table], objtype: type) -> Union[Self, T]:
         if obj is None:
             return self
+
+        # Cache the canonicalized subtable pa.Table per-instance, keyed on
+        # the parent table's identity so cache entries are naturally
+        # invalidated whenever the parent's pa.Table is replaced (e.g. via
+        # Attribute.__set__ on a mutable attribute or set_column returning
+        # a new instance). Each access still wraps the cached pa.Table in
+        # a fresh quivr Table, so callers can mutate attributes on the
+        # returned view without affecting future reads of obj.<name>.
+        cache = obj.__dict__.get("_quivr_subtable_cache")
+        if cache is None:
+            cache = {}
+            obj.__dict__["_quivr_subtable_cache"] = cache
+        else:
+            entry = cache.get(self.name)
+            if entry is not None and entry[0] is obj.table:
+                return self.table_type(entry[1])
+
         array = obj.table.column(self.name)
 
-        metadata = self.metadata
-        if metadata is None:
-            metadata = {}
-        metadata.update(obj._metadata_for_column(self.name))  # type: ignore
+        # Build the per-call metadata dict without mutating self.metadata,
+        # which is class-level state shared across instances.
+        column_metadata: dict[Byteslike, Byteslike] = {}
+        if self.metadata is not None:
+            column_metadata.update(self.metadata)
+        column_metadata.update(obj._metadata_for_column(self.name))  # type: ignore
 
-        schema = self.schema.with_metadata(metadata)
+        schema = self.schema.with_metadata(column_metadata)
 
         subtable = pa.Table.from_arrays(array.flatten(), schema=schema)
         # We don't validate the subtable. If the parent table was validated,
@@ -247,7 +266,9 @@ class SubTableColumn(Column, Generic[T]):
         # If the parent table is intentionally not validated, then we don't
         # want to validate the subtable at this time as it will throw an error
         # when accessing the subtable as a column (e.g. during concatenation).
-        return self.table_type.from_pyarrow(subtable, permit_nulls=self.nullable, validate=False)
+        result = self.table_type.from_pyarrow(subtable, permit_nulls=self.nullable, validate=False)
+        cache[self.name] = (obj.table, result.table)
+        return result
 
     def _nulls(self, n: int) -> pa.Array:
         """Return an array of nulls of the appropriate size."""

--- a/quivr/concat.py
+++ b/quivr/concat.py
@@ -32,39 +32,34 @@ def concatenate(
     # Note, we don't return immediately if there is only one table,
     # because we still want to optionally defragment the result.
 
-    batches = []
-    first_full = False
-
-    # Find the first non-empty table to get the class
+    first_cls = values_list[0].__class__
+    first_val = values_list[0]
+    # Find the first non-empty table to get the class for attribute comparison
     for v in values_list:
-        if not first_full and len(v) > 0:
+        if len(v) > 0:
             first_cls = v.__class__
             first_val = v
-            first_full = True
             break
 
-    # No non-empty tables found so lets pick the first table
-    # to get the class and attributes
-    if not first_full:
-        first_cls = values_list[0].__class__
-        first_val = values_list[0]
-
-    # Scan the values and now make sure they are all the same class
-    # as the first non-empty table
+    pa_tables = []
     for v in values_list:
-        batches += v.table.to_batches()
         if v.__class__ != first_cls:
             raise errors.TablesNotCompatibleError("All tables must be the same class to concatenate")
         if not first_val._attr_equal(v) and len(v) > 0:
             raise errors.TablesNotCompatibleError(
                 "All non-empty tables must have the same attribute values to concatenate"
             )
+        # Skip empty tables: their metadata can override that of non-empty
+        # tables (pa.concat_tables takes schema from the first input), and
+        # they contribute no rows.
+        if len(v) > 0:
+            pa_tables.append(v.table)
 
-    if len(batches) == 0:
-        # Return the first table, to preserve the attributes
+    if not pa_tables:
+        # All tables were empty; return the first to preserve attributes.
         table = first_val.table
     else:
-        table = pa.Table.from_batches(batches)
+        table = pa.concat_tables(pa_tables)
 
     # We re-initialize the table to optionally validate and create
     # a unique object

--- a/quivr/linkage.py
+++ b/quivr/linkage.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Generic, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
+import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from . import concat, errors, tables
 
@@ -12,27 +14,88 @@ class ArrowArrayIndex:
     Represents an index over the values in a PyArrow Array.
     """
 
-    index: dict[pa.Scalar, pa.UInt64Array]
+    index: dict[pa.Scalar, pa.Array]
     values: set[pa.Scalar]
 
     def __init__(self, array: pa.Array):
-        self.index = {}
-        self.values = set()
-
         if array.null_count > 0:
             raise ValueError("Array must not contain null values to be an index")
 
-        in_progress_index: dict[pa.Scalar, list[pa.Scalar]] = {}
+        n = len(array)
+        if n == 0:
+            self.index = {}
+            self.values = set()
+            return
+
+        # Group positions by value without wrapping every element in a
+        # pa.Scalar in Python. For primitives, use dictionary_encode to
+        # get integer codes; for struct arrays (used by MultiKeyLinkage),
+        # dictionary_encode is not supported, so encode each field
+        # separately and lexsort the resulting integer columns. If a key
+        # type rejects dictionary_encode (e.g. nested struct/list fields),
+        # fall back to the original element-by-element grouping.
+        try:
+            order, diff_any = self._compute_order(array, n)
+        except pa.lib.ArrowNotImplementedError:
+            self._init_fallback(array)
+            return
+
+        change_points = np.flatnonzero(diff_any) + 1
+        boundaries = np.concatenate(([0], change_points, [n])).astype(np.int64)
+
+        # Resolve all unique keys with a single Arrow take(), and slice
+        # the (zero-copy) pyarrow array of positions for each group.
+        first_positions = order[boundaries[:-1]]
+        keys_array = array.take(pa.array(first_positions))
+        order_arr = pa.array(order)
+
+        index: dict[pa.Scalar, pa.Array] = {}
+        for b in range(len(boundaries) - 1):
+            start = int(boundaries[b])
+            length = int(boundaries[b + 1]) - start
+            index[keys_array[b]] = order_arr.slice(start, length)
+
+        self.index = index
+        self.values = set(index.keys())
+
+    @staticmethod
+    def _compute_order(array: pa.Array, n: int) -> Tuple[np.ndarray, np.ndarray]:
+        if pa.types.is_struct(array.type):
+            field_codes = []
+            for field in array.type:
+                ef = pc.dictionary_encode(array.field(field.name))
+                if isinstance(ef, pa.ChunkedArray):
+                    ef = ef.combine_chunks()
+                field_codes.append(ef.indices.to_numpy(zero_copy_only=False))
+            # np.lexsort treats the LAST key as primary, so reverse the
+            # field list to sort by first field primarily.
+            order = np.lexsort(field_codes[::-1])
+            if n == 1:
+                diff_any = np.zeros(0, dtype=bool)
+            else:
+                diff_any = np.zeros(n - 1, dtype=bool)
+                for fc in field_codes:
+                    diff_any |= np.diff(fc[order]) != 0
+            return order, diff_any
+
+        encoded = pc.dictionary_encode(array)
+        if isinstance(encoded, pa.ChunkedArray):
+            encoded = encoded.combine_chunks()
+        codes = encoded.indices.to_numpy(zero_copy_only=False)
+        order = np.argsort(codes, kind="stable")
+        diff_any = np.diff(codes[order]) != 0 if n > 1 else np.zeros(0, dtype=bool)
+        return order, diff_any
+
+    def _init_fallback(self, array: pa.Array) -> None:
+        in_progress: dict[pa.Scalar, list[int]] = {}
         for i in range(len(array)):
             val = array[i]
-            if val in in_progress_index:
-                in_progress_index[val].append(i)
+            if val in in_progress:
+                in_progress[val].append(i)
             else:
-                in_progress_index[val] = [i]
-            self.values.add(val)
-
-        for val, indices in in_progress_index.items():
-            self.index[val] = pa.array(indices)
+                in_progress[val] = [i]
+        self.index = {val: pa.array(idx) for val, idx in in_progress.items()}
+        self.values = set(self.index.keys())
 
     def get(self, val: pa.Scalar) -> Optional[pa.UInt64Array]:
         return self.index.get(val, None)

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -45,8 +45,7 @@ class ArrowArrayProvider(Protocol):
     A Protocol which describes objects that support the Arrow custom array extension protocol.
     """
 
-    def __arrow_array__(self, type: Optional[pa.DataType] = None) -> pa.Array:
-        ...
+    def __arrow_array__(self, type: Optional[pa.DataType] = None) -> pa.Array: ...
 
 
 AttributeValueType: TypeAlias = Union[int, float, str]
@@ -64,6 +63,7 @@ _FORBIDDEN_COLUMN_NAMES = {
     "_quivr_subtables",
     "_quivr_attributes",
     "_column_validators",
+    "_quivr_subtable_cache",
 }
 
 

--- a/quivr/tables.py
+++ b/quivr/tables.py
@@ -45,7 +45,8 @@ class ArrowArrayProvider(Protocol):
     A Protocol which describes objects that support the Arrow custom array extension protocol.
     """
 
-    def __arrow_array__(self, type: Optional[pa.DataType] = None) -> pa.Array: ...
+    def __arrow_array__(self, type: Optional[pa.DataType] = None) -> pa.Array:
+        ...
 
 
 AttributeValueType: TypeAlias = Union[int, float, str]
@@ -1027,12 +1028,16 @@ class Table:
 
     def null_mask(self) -> pa.Array:
         """Return a boolean mask indicating which rows of the entire table are null."""
-        # Get the null mask for each column
         flattened_table = self.flattened_table()
-        mask = pa.repeat(True, len(flattened_table))
-        for name in flattened_table.column_names:
-            mask = pc.and_(mask, pc.is_null(flattened_table.column(name)))
-        return pa.array(mask, type=pa.bool_())
+        columns = flattened_table.columns
+        if not columns:
+            return pa.array([], type=pa.bool_())
+        mask = pc.is_null(columns[0])
+        for col in columns[1:]:
+            mask = pc.and_(mask, pc.is_null(col))
+        if isinstance(mask, pa.ChunkedArray):
+            mask = mask.combine_chunks()
+        return mask
 
     @classmethod
     def empty(cls, **kwargs: AttributeValueType) -> Self:


### PR DESCRIPTION
## Summary

Four targeted fixes to measured hot paths. All 302 existing tests pass; 14 additional edge-case stress checks pass. Numbers below are minimum over 7 runs.

| Path | Before | After | Speedup |
|---|--:|--:|--:|
| `Table.null_mask` (1M × 3 nullable cols) | 648.28 ms | 0.13 ms | **5172x** |
| 5k `outer.inner` subtable accesses | 148.38 ms | 3.95 ms | **37.5x** |
| `ArrowArrayIndex` (50k keys, ~5k unique) | 87.21 ms | 14.39 ms | **6x** |
| `Linkage` build (same fixture) | 178.76 ms | 35.27 ms | **5x** |
| `quivr.concatenate` (100 × 1k, defrag/validate=False) | 0.184 ms | 0.088 ms | **2.1x** |

## Commits

1. **Fix `Table.null_mask` 5000x slowdown** — trailing `pa.array(chunked_array, ...)` was iterating a ChunkedArray as a Python sequence and materializing scalars one at a time. Drop the redundant materialization, fold from the first column's null mask, combine_chunks only when chunked.

2. **Use `pa.concat_tables` in `quivr.concatenate`** — replace the `to_batches()` / `from_batches()` round-trip with the canonical pyarrow path. Empty tables are filtered before concatenation so their schema metadata cannot override that of non-empty inputs (`pa.concat_tables` takes its schema from the first input). Behavior covered by `test_concatenate_default_attrs_empty` is preserved.

3. **Vectorize `ArrowArrayIndex` construction** — the original index built `dict[pa.Scalar -> list[int]]` by wrapping every element in a `pa.Scalar` inside a Python loop. Replace with `pc.dictionary_encode` + numpy argsort/lexsort to find run-length boundaries, a single Arrow `take()` to resolve unique keys, and zero-copy slicing of one `pa.array(order)` into per-group index arrays. Struct-array keys (used by `MultiKeyLinkage`) take a per-field encode + lexsort path; nested struct/list field types fall back to the original element-by-element loop.

4. **Cache `SubTableColumn` views and stop mutating `self.metadata`** — two issues fixed together:
   - `metadata = self.metadata; metadata.update(...)` mutated the dict stored on the class-level `Column` descriptor. The first `obj.<name>` access leaked instance-specific metadata onto the shared descriptor; every later instance saw it. Build the per-call metadata dict in a fresh local instead.
   - Each `obj.<name>` read rebuilt the entire subtable view (column lookup, struct flatten, `pa.Table.from_arrays`, `from_pyarrow` schema canonicalization) at ~30 µs/call. Cache the canonicalized subtable `pa.Table` on the parent instance's `__dict__` keyed on the parent's `pa.Table` identity. The cache is invalidated naturally when the parent's `pa.Table` is replaced (e.g. mutable `Attribute.__set__`, `set_column` returning a new parent). Each access still wraps the cached `pa.Table` in a fresh `Table` instance, so callers can mutate attributes on the returned view without those mutations leaking into future reads (preserved by `test_nested_table_mutability`).
   - `_quivr_subtable_cache` added to `_FORBIDDEN_COLUMN_NAMES` to prevent column-name collisions with the cache key.

## Test plan
- [x] `pytest --benchmark-disable test/ --ignore=test/test_query_speed.py` — 302 passed.
- [x] Stress edge cases (empty/single/all-unique/all-same linkage, NaN-free float keys, nested struct linkage via fallback, parent-attr-mutation cache invalidation, subtable-view mutation isolation, all-empty concat, empty+populated concat metadata precedence, all-null/no-null/empty `null_mask`, concat with subtable schema).
- [x] Per-commit and cumulative perf benchmarks reproduced from a fixed harness.

Note: `test/test_query_speed.py` is broken on `main` (uses a non-existent `from_data` classmethod) and is excluded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)